### PR TITLE
Fix 7-item limit

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,6 @@
 @CHARSET "UTF-8";
 html {  width: 400px; height: auto; }
-body{ font-family: Arial, Tahoma, sans-serif; font-size: 11px; padding:0; margin:0 auto;background: #fff;overflow: hidden;}
+body{ font-family: Arial, Tahoma, sans-serif; font-size: 11px; padding:0; margin:0 auto;background: #fff;overflow: scroll;}
 a {text-decoration: none;color:#555;}
 
 /* top bar


### PR DESCRIPTION
Removing the `overflow:hidden` on body and replacing it with `overflow:scroll` will allow more than 7 or so items to be seen.